### PR TITLE
Pro controller dirty fix

### DIFF
--- a/jctool.vs2017-net4.7.1.sln
+++ b/jctool.vs2017-net4.7.1.sln
@@ -1,23 +1,31 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34316.72
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jctool", "jctool\jctool.vs2017.vcxproj", "{DF218734-A810-4FFF-8164-638680773512}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jcColorDialog", "jctool\jc_colorpicker\jcColorDialog.vs2017.csproj", "{22E08F67-4E40-4A92-876B-410FFD49B20E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jcColorDialog.vs2017", "jctool\jc_colorpicker\jcColorDialog.vs2017.csproj", "{22E08F67-4E40-4A92-876B-410FFD49B20E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DF218734-A810-4FFF-8164-638680773512}.Debug|x86.ActiveCfg = Debug|Win32
+		{DF218734-A810-4FFF-8164-638680773512}.Debug|x86.Build.0 = Debug|Win32
 		{DF218734-A810-4FFF-8164-638680773512}.Release|x86.ActiveCfg = Release|Win32
 		{DF218734-A810-4FFF-8164-638680773512}.Release|x86.Build.0 = Release|Win32
+		{22E08F67-4E40-4A92-876B-410FFD49B20E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{22E08F67-4E40-4A92-876B-410FFD49B20E}.Debug|x86.Build.0 = Debug|Any CPU
 		{22E08F67-4E40-4A92-876B-410FFD49B20E}.Release|x86.ActiveCfg = Release|Any CPU
 		{22E08F67-4E40-4A92-876B-410FFD49B20E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A9125772-48FF-48EB-836D-4840AE345A38}
 	EndGlobalSection
 EndGlobal

--- a/jctool/jc_colorpicker/jcColorDialog.vs2017.csproj
+++ b/jctool/jc_colorpicker/jcColorDialog.vs2017.csproj
@@ -67,6 +67,16 @@
     <PlatformTarget>x86</PlatformTarget>
     <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <OutputPath>bin\Debug\</OutputPath>
+    <BaseAddress>285212672</BaseAddress>
+    <Optimize>true</Optimize>
+    <FileAlignment>4096</FileAlignment>
+    <PlatformTarget>x86</PlatformTarget>
+    <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System">
       <Name>System</Name>

--- a/jctool/jctool.cpp
+++ b/jctool/jctool.cpp
@@ -2967,6 +2967,7 @@ int device_connection(){
             handle_ok = 2;
             return handle_ok;
         }
+        Sleep(1); //For some reason, adding a bit of delay here makes the handle call below work properly, which allows pro controller to connect.
         // Pro Controller
         if (handle = hid_open(0x57e, 0x2009, nullptr)) {
             handle_ok = 3;
@@ -2991,7 +2992,7 @@ int device_connection(){
                         L"CTCaer's Joy-Con Toolkit - Third-Party Device Detected",
                         MessageBoxButtons::YesNo, MessageBoxIcon::Warning) == System::Windows::Forms::DialogResult::Yes)
                     {
-                        if (handle = hid_open(cur_dev->product_id, cur_dev->vendor_id, cur_dev->serial_number)) {
+                        if (handle = hid_open(cur_dev->vendor_id, cur_dev->product_id, cur_dev->serial_number)) { //product & vendor parameters were switched, function call would always fail
                             // Maybe do some more tests here just to double check
                             hid_free_enumeration(devs);
                             handle_ok = 3;

--- a/jctool/jctool.vs2017.vcxproj
+++ b/jctool/jctool.vs2017.vcxproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -8,19 +12,27 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DF218734-A810-4FFF-8164-638680773512}</ProjectGuid>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>jctool</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>jctool</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CLRSupport>true</CLRSupport>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -31,8 +43,16 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <EnableManagedIncrementalBuild>false</EnableManagedIncrementalBuild>
+    <EmbedManifest>true</EmbedManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <EnableManagedIncrementalBuild>false</EnableManagedIncrementalBuild>
     <EmbedManifest>true</EmbedManifest>
@@ -50,6 +70,39 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <AdditionalDependencies />
+      <SubSystem>Windows</SubSystem>
+      <EntryPointSymbol>Main</EntryPointSymbol>
+      <Version>
+      </Version>
+      <ImportLibrary>$(Configuration)\$(TargetName).lib</ImportLibrary>
+    </Link>
+    <EmbeddedResource>
+      <LogicalName>
+      </LogicalName>
+    </EmbeddedResource>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)dpiawarev2.manifest.xml</AdditionalManifestFiles>
+      <EnableDpiAwareness>false</EnableDpiAwareness>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DebugInformationFormat>None</DebugInformationFormat>
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <EntryPointSymbol>Main</EntryPointSymbol>
       <Version>
@@ -102,14 +155,17 @@
       <DependentUpon>FormJoy.h</DependentUpon>
       <SubType>Designer</SubType>
       <LogicalName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CppWinFormJoy.FormJoy.resources</LogicalName>
+      <LogicalName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CppWinFormJoy.FormJoy.resources</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="images.resx">
       <LogicalName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CppWinFormJoy.images.resources</LogicalName>
+      <LogicalName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CppWinFormJoy.images.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Resource.rc">
       <Culture Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">0x0409</Culture>
+      <Culture Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">0x0409</Culture>
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Adding a Sleep() line, which for some dark magic reason allows pro controllers to be detected as such and connect.

Quick fix for a typo in the third-party controllers detection routine, now third party controllers should be detected and allowed to connect (no idea how the program then behaves when editing those though).
